### PR TITLE
Fix deploy workflow to use master branch instead of main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,12 +3,12 @@ name: Deploy Docusaurus Documentation
 on:
   push:
     branches:
-      - main
+      - master
     paths:
       - 'docs-ui/**'
   pull_request:
     branches:
-      - main
+      - master
     paths:
       - 'docs-ui/**'
 
@@ -62,7 +62,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/master'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
- Update GitHub Actions workflow triggers from main to master
- Fix deployment condition to check refs/heads/master
- Ensures workflow triggers correctly on this repository's base branch